### PR TITLE
fix text dat file location when out of tree build

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -36,7 +36,8 @@ CLEANFILES		= $(binary_model_data)
 
 interpolation.text:
 	wget https://github.com/downloads/libpinyin/libpinyin/model.text.tar.gz
-	tar xvf model.text.tar.gz
+	tar xvf model.text.tar.gz -C $(top_srcdir)/data
+
 
 gb_char.table gbk_char.table: interpolation.text
 


### PR DESCRIPTION
When building out of source code tree( which is preferable in some situation), $(top_srcdir) and $(top_builddir) are no longer the same, making generating bin db fail. This patch fixes the issue.
