### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/src/lookup/CMakeLists.txt
+++ b/src/lookup/CMakeLists.txt
@@ -4,8 +4,7 @@ set(
 
 set(
     LIBLOOKUP_SOURCES
-    pinyin_lookup.cpp
-    winner_tree.cpp
+    pinyin_lookup2.cpp
     phrase_lookup.cpp
     lookup.cpp
 )

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -11,7 +11,7 @@ set(
 set(
     LIBSTORAGE_SOURCES
     phrase_index.cpp
-    phrase_large_table.cpp
+    phrase_large_table2.cpp
     ngram.cpp
     tag_utility.cpp
     pinyin_parser2.cpp


### PR DESCRIPTION
CMakeLists.txt pointed to non-existent files...

BTW, why you use many 2's in file names and class names?
