### PR TITLE
resolve build errors

### DIFF
--- a/src/lookup/phrase_lookup.cpp
+++ b/src/lookup/phrase_lookup.cpp
@@ -38,7 +38,7 @@ static bool populate_prefixes(GPtrArray * steps_index,
                               GPtrArray * steps_content) {
 
     lookup_key_t initial_key = sentence_start;
-    lookup_value_t initial_value(log(1));
+    lookup_value_t initial_value(log(1.f));
     initial_value.m_handles[1] = sentence_start;
 
     LookupStepContent initial_step_content = (LookupStepContent)

--- a/src/lookup/pinyin_lookup2.cpp
+++ b/src/lookup/pinyin_lookup2.cpp
@@ -133,7 +133,7 @@ static bool populate_prefixes(GPtrArray * steps_index,
     for (size_t i = 0; i < prefixes->len; ++i) {
         phrase_token_t token = g_array_index(prefixes, phrase_token_t, i);
         lookup_key_t initial_key = token;
-        lookup_value_t initial_value(log(1));
+        lookup_value_t initial_value(log(1.f));
         initial_value.m_handles[1] = token;
 
         LookupStepContent initial_step_content = (LookupStepContent)

--- a/src/storage/phrase_index.cpp
+++ b/src/storage/phrase_index.cpp
@@ -624,7 +624,7 @@ int SubPhraseIndex::get_range(/* out */ PhraseIndexRange & range){
     /* remove trailing zeros. */
     const table_offset_t * poffset = NULL;
     for (poffset = end; poffset > begin + 1; --poffset) {
-        if (NULL !=  *(poffset - 1))
+        if (0 !=  *(poffset - 1))
             break;
     }
 


### PR DESCRIPTION
* NULL must not be used in arithmetic in C++
* log(1) is ambiguos, log(float) or log(double) or ... no log(int)