### PR TITLE
include config.h to allow using getline on freebsd

### DIFF
--- a/tests/test_zhuyin.cpp
+++ b/tests/test_zhuyin.cpp
@@ -19,6 +19,10 @@
  */
 
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "zhuyin.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/utils/storage/gen_zhuyin_table.cpp
+++ b/utils/storage/gen_zhuyin_table.cpp
@@ -19,6 +19,10 @@
  */
 
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdio.h>
 #include <glib.h>
 #include "pinyin_internal.h"


### PR DESCRIPTION
This is the same as the second issue described in https://github.com/libpinyin/libpinyin/issues/65. It is a minimal patch for libzhuyin-enabled build.