### PR TITLE
Fix CMake build: missing ../data/table.conf

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -45,6 +45,7 @@ add_custom_command(
         ${CMAKE_SOURCE_DIR}/data/gb_char.table
         ${CMAKE_SOURCE_DIR}/data/gbk_char.table
         ${CMAKE_SOURCE_DIR}/data/interpolation2.text
+        ${CMAKE_SOURCE_DIR}/data/table.conf
     COMMENT
         "Downloading textual model data..."
     COMMAND


### PR DESCRIPTION
Add data/table.conf as a output target from downloaded textual model data, so that it can be found during the build phase.