### PR TITLE
Fix include issue with auto-generated config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 include_directories(
+    ${CMAKE_BINARY_DIR}
     ${GLIB2_INCLUDE_DIR}
     ${PROJECT_SOURCE_DIR}/
     ${PROJECT_SOURCE_DIR}/src


### PR DESCRIPTION
Add `${CMAKE_BINARY_DIR}` into include path to make
`${CMAKE_BINARY_DIR}/config.h` visible to source codes.