### PR TITLE
Allow using local copy of model data rather than downloading it in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ set (
 
 set (VERSION ${LIBPINYIN_VERSION})
 
+option(USE_SYSTEM_MODEL "Use model data from the system rather than downloading it in CMake" OFF)
+
 ######## Validation
 
 include(CheckIncludeFileCXX)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -40,19 +40,21 @@ add_custom_target(
         ${BINARY_MODEL_DATA}
 )
 
-add_custom_command(
-    OUTPUT
-        ${CMAKE_SOURCE_DIR}/data/gb_char.table
-        ${CMAKE_SOURCE_DIR}/data/gbk_char.table
-        ${CMAKE_SOURCE_DIR}/data/interpolation2.text
-        ${CMAKE_SOURCE_DIR}/data/table.conf
-    COMMENT
-        "Downloading textual model data..."
-    COMMAND
-       wget http://downloads.sourceforge.net/libpinyin/models/model17.text.tar.gz
-    COMMAND
-       tar xvf model17.text.tar.gz -C ${CMAKE_SOURCE_DIR}/data
-)
+if (NOT USE_SYSTEM_MODEL)
+    add_custom_command(
+        OUTPUT
+	    ${CMAKE_SOURCE_DIR}/data/gb_char.table
+            ${CMAKE_SOURCE_DIR}/data/gbk_char.table
+            ${CMAKE_SOURCE_DIR}/data/interpolation2.text
+            ${CMAKE_SOURCE_DIR}/data/table.conf
+        COMMENT
+            "Downloading textual model data..."
+        COMMAND
+           wget http://downloads.sourceforge.net/libpinyin/models/model17.text.tar.gz
+        COMMAND
+           tar xvf model17.text.tar.gz -C ${CMAKE_SOURCE_DIR}/data
+    )
+endif()
 
 add_custom_command(
     OUTPUT


### PR DESCRIPTION
Fixes #121