### PR TITLE
CMake: enable tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,8 @@ target_link_libraries(
     pinyin
 )
 
+add_test(NAME pinyin COMMAND test_pinyin)
+
 add_executable(
     test_phrase
     test_phrase.cpp
@@ -22,6 +24,8 @@ target_link_libraries(
     pinyin
 )
 
+add_test(NAME phrase COMMAND test_phrase)
+
 add_executable(
     test_chewing
     test_chewing.cpp
@@ -31,3 +35,5 @@ target_link_libraries(
     test_chewing
     pinyin
 )
+
+add_test(NAME chewing COMMAND test_chewing)


### PR DESCRIPTION
CMake never actually generated a test target, this fixes that.

However, the tests expect the data folder in a specific directory, so this prevents out-of-source builds (e.g. `cmake -B build`).
Also, it seems that the tests never actually finish, it seems to be stuck in an infinite loop (the `pinyin` test anyway).