### PR TITLE
Fix delimiter for reading table files on macOS

### DIFF
--- a/src/storage/chewing_large_table.cpp
+++ b/src/storage/chewing_large_table.cpp
@@ -669,8 +669,13 @@ bool ChewingLargeTable::load_text(FILE * infile, TABLE_PHONETIC_TYPE type) {
     size_t freq;
 
     while (!feof(infile)) {
+#ifdef __APPLE__
+        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
+                         pinyin, phrase, &token, &freq);
+#else
         int num = fscanf(infile, "%255s %255s %u %ld",
                          pinyin, phrase, &token, &freq);
+#endif
 
         if (4 != num)
             continue;

--- a/src/storage/chewing_large_table2.cpp
+++ b/src/storage/chewing_large_table2.cpp
@@ -115,8 +115,13 @@ bool ChewingLargeTable2::load_text(FILE * infile, TABLE_PHONETIC_TYPE type) {
     size_t freq;
 
     while (!feof(infile)) {
+#ifdef __APPLE__
+        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
+                         pinyin, phrase, &token, &freq);
+#else
         int num = fscanf(infile, "%255s %255s %u %ld",
                          pinyin, phrase, &token, &freq);
+#endif
 
         if (4 != num)
             continue;

--- a/src/storage/phrase_index.cpp
+++ b/src/storage/phrase_index.cpp
@@ -527,8 +527,13 @@ bool FacadePhraseIndex::load_text(guint8 phrase_index, FILE * infile,
     phrase_token_t cur_token = 0;
 
     while (!feof(infile)){
+#ifdef __APPLE__
+        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
+                         pinyin, phrase, &token, &freq);
+#else
         int num = fscanf(infile, "%255s %255s %u %ld",
                          pinyin, phrase, &token, &freq);
+#endif
 
         if (4 != num)
             continue;

--- a/src/storage/phrase_large_table2.cpp
+++ b/src/storage/phrase_large_table2.cpp
@@ -472,8 +472,13 @@ bool PhraseLargeTable2::load_text(FILE * infile){
     size_t freq;
 
     while (!feof(infile)) {
+#ifdef __APPLE__
+        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
+                         pinyin, phrase, &token, &freq);
+#else
         int num = fscanf(infile, "%255s %255s %u %ld",
                          pinyin, phrase, &token, &freq);
+#endif
 
         if (4 != num)
             continue;

--- a/src/storage/phrase_large_table3.cpp
+++ b/src/storage/phrase_large_table3.cpp
@@ -128,8 +128,13 @@ bool PhraseLargeTable3::load_text(FILE * infile){
     size_t freq;
 
     while (!feof(infile)) {
+#ifdef __APPLE__
+        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
+                         pinyin, phrase, &token, &freq);
+#else
         int num = fscanf(infile, "%255s %255s %u %ld",
                          pinyin, phrase, &token, &freq);
+#endif
 
         if (4 != num)
             continue;


### PR DESCRIPTION
On macOS under llvm/clang++, the default delimiter for format string is
weird: it cannot read full CJK characters from the table files.

This patch adds macOS-specified code to make "\t" and " " the implicit
delimiter.

Ref:
https://stackoverflow.com/questions/12885628/changing-the-scanf-delimiter