### PR TITLE
Crossbuilding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,11 @@ check_type_size(size_t SIZE_OF_SIZE_T)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(GLIB2 REQUIRED)
 
+# Options
+
+# For cross-building enable installation of data dirs and set the DATA_UTILS_PATH variable
+option(INSTALL_DATA_UTILS "Install data utilities" OFF)
+
 # DBM: BerkeleyDB
 find_package(BerkeleyDB)
 if (DB_FOUND)
@@ -106,6 +111,13 @@ set (DIR_INCLUDE ${DIR_PREFIX}/include)
 set (DIR_SHARE ${DIR_PREFIX}/share)
 set (DIR_BIN ${DIR_PREFIX}/bin)
 set (DIR_ETC ${DIR_PREFIX}/etc)
+if (NOT DEFINED DATA_UTILS_PATH)
+    set(DATA_UTILS_STORAGE_PATH ${CMAKE_BINARY_DIR}/utils/storage)
+    set(DATA_UTILS_TRAINING_PATH ${CMAKE_BINARY_DIR}/utils/training)
+else()
+    set(DATA_UTILS_STORAGE_PATH ${DATA_UTILS_PATH})
+    set(DATA_UTILS_TRAINING_PATH ${DATA_UTILS_PATH})
+endif()
 
 if (DEFINED CMAKE_INSTALL_LIBDIR)
     set (DIR_LIBRARY ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ find_package(GLIB2 REQUIRED)
 
 # For cross-building enable installation of data dirs and set the DATA_UTILS_PATH variable
 option(INSTALL_DATA_UTILS "Install data utilities" OFF)
+option(DOWNLOAD_MODEL_DATA_ARCHIVE "Update the model data archive while building" ON)
 
 # DBM: BerkeleyDB
 find_package(BerkeleyDB)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -20,17 +20,17 @@ set(
 
 set(
     gen_binary_files_BIN
-    ${CMAKE_BINARY_DIR}/utils/storage/gen_binary_files
+    ${DATA_UTILS_STORAGE_PATH}/gen_binary_files
 )
 
 set(
     import_interpolation_BIN
-    ${CMAKE_BINARY_DIR}/utils/storage/import_interpolation
+    ${DATA_UTILS_STORAGE_PATH}/import_interpolation
 )
 
 set(
     gen_unigram_BIN
-    ${CMAKE_BINARY_DIR}/utils/training/gen_unigram
+    ${DATA_UTILS_TRAINING_PATH}/gen_unigram
 )
 
 add_custom_target(

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -40,19 +40,35 @@ add_custom_target(
         ${BINARY_MODEL_DATA}
 )
 
-add_custom_command(
-    OUTPUT
-        ${CMAKE_SOURCE_DIR}/data/gb_char.table
-        ${CMAKE_SOURCE_DIR}/data/gbk_char.table
-        ${CMAKE_SOURCE_DIR}/data/interpolation2.text
-        ${CMAKE_SOURCE_DIR}/data/table.conf
-    COMMENT
-        "Downloading textual model data..."
-    COMMAND
-       wget http://downloads.sourceforge.net/libpinyin/models/model19.text.tar.gz
-    COMMAND
-       tar xvf model19.text.tar.gz -C ${CMAKE_SOURCE_DIR}/data
-)
+if(DOWNLOAD_MODEL_DATA_ARCHIVE)
+    add_custom_command(
+        OUTPUT
+            ${CMAKE_SOURCE_DIR}/data/gb_char.table
+            ${CMAKE_SOURCE_DIR}/data/gbk_char.table
+            ${CMAKE_SOURCE_DIR}/data/interpolation2.text
+            ${CMAKE_SOURCE_DIR}/data/table.conf
+        COMMENT
+            "Downloading textual model data..."
+        COMMAND
+        wget -P ${CMAKE_SOURCE_DIR} http://downloads.sourceforge.net/libpinyin/models/model19.text.tar.gz
+        COMMAND
+        tar xvf ${CMAKE_SOURCE_DIR}/model19.text.tar.gz -C ${CMAKE_SOURCE_DIR}/data
+    )
+else()
+    add_custom_command(
+        OUTPUT
+            ${CMAKE_SOURCE_DIR}/data/gb_char.table
+            ${CMAKE_SOURCE_DIR}/data/gbk_char.table
+            ${CMAKE_SOURCE_DIR}/data/interpolation2.text
+            ${CMAKE_SOURCE_DIR}/data/table.conf
+        COMMENT
+            "Checking if model data is provided in ${CMAKE_SOURCE_DIR}/model19.text.tar.gz"
+        COMMAND
+        test -f ${CMAKE_SOURCE_DIR}/model19.text.tar.gz
+        COMMAND
+        tar xvf ${CMAKE_SOURCE_DIR}/model19.text.tar.gz -C ${CMAKE_SOURCE_DIR}/data
+    )
+endif()
 
 add_custom_command(
     OUTPUT

--- a/utils/storage/CMakeLists.txt
+++ b/utils/storage/CMakeLists.txt
@@ -7,6 +7,14 @@ target_link_libraries(
     gen_binary_files
     pinyin
 )
+if(INSTALL_DATA_UTILS)
+    install(
+        TARGETS
+            gen_binary_files
+        RUNTIME DESTINATION
+            ${DIR_BIN}
+    )
+endif()
 
 add_executable(
     import_interpolation
@@ -17,6 +25,14 @@ target_link_libraries(
     import_interpolation
     pinyin
 )
+if(INSTALL_DATA_UTILS)
+    install(
+        TARGETS
+            import_interpolation
+        RUNTIME DESTINATION
+            ${DIR_BIN}
+    )
+endif()
 
 add_executable(
     export_interpolation
@@ -27,3 +43,11 @@ target_link_libraries(
     export_interpolation
     pinyin
 )
+if(INSTALL_DATA_UTILS)
+    install(
+        TARGETS
+            export_interpolation
+        RUNTIME DESTINATION
+            ${DIR_BIN}
+    )
+endif()

--- a/utils/training/CMakeLists.txt
+++ b/utils/training/CMakeLists.txt
@@ -22,6 +22,14 @@ add_executable(
     gen_unigram
     gen_unigram.cpp
 )
+if(INSTALL_DATA_UTILS)
+    install(
+        TARGETS
+            gen_unigram
+        RUNTIME DESTINATION
+            ${DIR_BIN}
+    )
+endif()
 
 target_link_libraries(
     gen_unigram


### PR DESCRIPTION
Provided options to enabled cross-building in tools like Yocto, where need to build the tools for the host architecture and use them later in order to generate libraries and data for the target architecture.