### PR TITLE
Fix unaligned access in get_unigram_frequency()

### DIFF
--- a/src/storage/phrase_index.h
+++ b/src/storage/phrase_index.h
@@ -122,7 +122,9 @@ public:
      */
     guint32 get_unigram_frequency(){
         char * buf_begin = (char *)m_chunk.begin();
-        return (*(guint32 *)(buf_begin + sizeof(guint8) + sizeof(guint8)));
+        guint32 retval;
+        memcpy(&retval, buf_begin + sizeof(guint8) + sizeof(guint8), sizeof(guint32));
+        return retval;
     }
 
     /**


### PR DESCRIPTION
In Debian the testsuite of fcitx5-zhuyin failed on 32-bit ARM
runnning on 64-bit hardware:
https://buildd.debian.org/status/fetch.php?pkg=fcitx5-zhuyin&arch=armhf&ver=5.0.8-1&stamp=1657997016&raw=0

Backtrace:
```
#0  0xf7a1cd64 in pinyin::PhraseItem::get_unigram_frequency (this=0x1d78364)
    at ../src/storage/phrase_index.h:125
#1  pinyin::PhoneticLookup<1, 1>::unigram_gen_next_step (token=16777669, 
    cur_step=0x1d78c78, end=3, start=0, this=0x1d78358)
    at ../src/lookup/phonetic_lookup.h:649
#2  pinyin::PhoneticLookup<1, 1>::search_unigram2 (this=this@entry=0x1d78358, 
    topresults=topresults@entry=0x1d5f850, start=start@entry=0, 
    end=end@entry=3, ranges=ranges@entry=0xffc7fa2c)
    at ../src/lookup/phonetic_lookup.h:567
#3  0xf7a1d406 in pinyin::PhoneticLookup<1, 1>::get_nbest_match (
    this=0x1d78358, prefixes=<optimized out>, matrix=matrix@entry=0x1d785f0, 
    constraints=<optimized out>, results=results@entry=0x1d78600)
    at ../src/lookup/phonetic_lookup.h:809
#4  0xf7a1b8e8 in zhuyin_guess_sentence (instance=0x1d785e8) at zhuyin.cpp:904
#5  0x008bfda4 in fcitx::ZhuyinSection::typeImpl (this=0x1d78568, 
    s=<optimized out>, length=<optimized out>)
    at /usr/include/c++/11/bits/unique_ptr.h:173
#6  0xf7a93abe in fcitx::InputBuffer::type(unsigned int) ()
   from /usr/lib/arm-linux-gnueabihf/libFcitx5Utils.so.2
#7  0x008bd7a4 in fcitx::ZhuyinBuffer::type (this=this@entry=0xffc7fb54, 
    c=<optimized out>, c@entry=32) at ./src/zhuyinbuffer.cpp:90
#8  0x008bbc82 in test_basic () at ./test/testzhuyinbuffer.cpp:41
#9  0x008bccda in main () at ./test/testzhuyinbuffer.cpp:167
```

The problem was the unaligned access, memcpy() the data instead.