### PR TITLE
Fix libpinyin on ARMv7

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -22,4 +22,5 @@ libpinyininclude_HEADERS= novel_types.h
 
 noinst_HEADERS = memory_chunk.h \
                  pinyin_utils.h \
-                 stl_lite.h
+                 stl_lite.h \
+                 unaligned_memory.h

--- a/src/include/memory_chunk.h
+++ b/src/include/memory_chunk.h
@@ -134,7 +134,7 @@ private:
         /* checksum for aligned parts. */
         guint32 index = 0;
         for (; index < aligns; index += sizeof(guint32)) {
-            const char * p = data + index;
+            const unsigned char * p = (const unsigned char *)data + index;
 
             /* use little endian here. */
             guint32 item = *p | *(p + 1) << 8 |
@@ -146,7 +146,7 @@ private:
         /* checksum for remained parts. */
         guint32 shift = 0;
         for (; index < length; index++) {
-            const char * p = data + index;
+            const unsigned char * p = (const unsigned char *)data + index;
 
             guint32 item = *p << shift;
             shift += 8;

--- a/src/include/memory_chunk.h
+++ b/src/include/memory_chunk.h
@@ -290,6 +290,25 @@ public:
     }
 
     /**
+     * MemoryChunk::set_content:
+     * @offset: the offset in this MemoryChunk.
+     * @data: the data to be copied.
+     * @returns: whether the data is copied successfully.
+     *
+     * Data are written directly to the memory area in this MemoryChunk.
+     *
+     */
+    template <typename T>
+    bool set_content(size_t offset, T data){
+        const size_t len = sizeof(data);
+        size_t cursize = std_lite::max(size(), offset + len);
+        ensure_has_space(offset + len);
+        memmove(m_data_begin + offset, &data, len);
+        m_data_end = m_data_begin + cursize;
+        return true;
+    }
+
+    /**
      * MemoryChunk::append_content:
      * @data: the begin of the data to be copied.
      * @len: the length of the data to be copied.
@@ -354,6 +373,21 @@ public:
             return false;
         memcpy( buffer, m_data_begin + offset, length);
         return true;
+    }
+
+    /**
+     * MemoryChunk::get_content:
+     * @offset: the offset in this MemoryChunk.
+     * @returns: the content
+     *
+     * Get the content in this MemoryChunk.
+     *
+     */
+    template <typename T>
+    T get_content(size_t offset) const {
+        T value;
+        memcpy(&value, m_data_begin + offset, sizeof(value));
+        return value;
     }
 
     /**

--- a/src/include/unaligned_memory.h
+++ b/src/include/unaligned_memory.h
@@ -1,0 +1,43 @@
+#ifndef UNALIGNED_MEMORY_H
+#define UNALIGNED_MEMORY_H
+
+#include <cstring>
+
+/**
+ * UnalignedMemory: Safe unaligned memory access.
+ * 
+ * Some instruction sets, or some instructions in some instruction sets
+ * require that memory access is aligned to a specific boundary. These
+ * instructions may trap on unaligned access.
+ * 
+ * This class provides methods to load and store values at unaligned
+ * addresses. It ensures that the compiler doesn't generate instructions
+ * that could trap on the unaligned memory access.
+ */
+
+namespace pinyin{
+    template <typename T>
+    class UnalignedMemory{
+    public:
+        /**
+         * Read a value from a possibly unaligned memory address.
+         * 
+         */
+        static T load(const void * src) {
+            T value;
+            memcpy(&value, src, sizeof(T));
+            return value;
+        }
+
+        /**
+         * Store a value into a possibly unaligned memory address.
+         * 
+         */
+        static void store(T value, void * dest) {
+            memcpy(dest, &value, sizeof(T));
+        }
+    };
+};
+
+
+#endif

--- a/src/storage/chewing_large_table.cpp
+++ b/src/storage/chewing_large_table.cpp
@@ -804,7 +804,7 @@ bool ChewingBitmapIndexLevel::store(MemoryChunk * new_chunk,
 bool ChewingLengthIndexLevel::load(MemoryChunk * chunk, table_offset_t offset,
                                    table_offset_t end) {
     char * begin = (char *) chunk->begin();
-    guint32 nindex = *((guint32 *)(begin + offset)); /* number of index */
+    guint32 nindex = chunk->get_content<guint32>(offset); /* number of index */
     table_offset_t * index = (table_offset_t *)
         (begin + offset + sizeof(guint32));
 

--- a/src/storage/ngram.cpp
+++ b/src/storage/ngram.cpp
@@ -46,14 +46,12 @@ SingleGram::SingleGram(void * buffer, size_t length, bool copy){
 }
 
 bool SingleGram::get_total_freq(guint32 & total) const{
-    char * buf_begin = (char *)m_chunk.begin();
-    total = *((guint32 *)buf_begin);
+    total = m_chunk.get_content<guint32>(0);
     return true;
 }
 
 bool SingleGram::set_total_freq(guint32 total){
-    char * buf_begin = (char *)m_chunk.begin();
-    *((guint32 *)buf_begin) = total;
+    m_chunk.set_content<guint32>(0, total);
     return true;
 }
 

--- a/src/storage/phrase_index.h
+++ b/src/storage/phrase_index.h
@@ -31,6 +31,7 @@
 #include "memory_chunk.h"
 #include "phrase_index_logger.h"
 #include "table_info.h"
+#include "unaligned_memory.h"
 
 /**
  * Phrase Index File Format
@@ -121,8 +122,7 @@ public:
      *
      */
     guint32 get_unigram_frequency(){
-        char * buf_begin = (char *)m_chunk.begin();
-        return (*(guint32 *)(buf_begin + sizeof(guint8) + sizeof(guint8)));
+        return m_chunk.get_content<guint32>(sizeof(guint8) + sizeof(guint8));
     }
 
     /**
@@ -142,12 +142,13 @@ public:
         for ( int i = 0 ; i < npron ; ++i){
             char * chewing_begin = buf_begin + offset +
                 i * (phrase_length * sizeof(ChewingKey) + sizeof(guint32));
-            guint32 * freq = (guint32 *)(chewing_begin +
-                                         phrase_length * sizeof(ChewingKey));
-            total_freq += *freq;
+            
+            guint32 freq = UnalignedMemory<guint32>::load(chewing_begin +
+                                                          phrase_length * sizeof(ChewingKey));
+            total_freq += freq;
             if ( 0 == pinyin_compare_with_tones(keys, (ChewingKey *)chewing_begin,
                                                 phrase_length) ){
-                matched += *freq;
+                matched += freq;
             }
         }
 

--- a/src/storage/phrase_large_table2.cpp
+++ b/src/storage/phrase_large_table2.cpp
@@ -561,7 +561,8 @@ bool PhraseLengthIndexLevel2::load(MemoryChunk * chunk,
                                    table_offset_t offset,
                                    table_offset_t end) {
     char * buf_begin = (char *) chunk->begin();
-    guint32 nindex = *((guint32 *)(buf_begin + offset));
+    guint32 nindex = chunk->get_content<guint32>(offset);
+
     table_offset_t * index = (table_offset_t *)
         (buf_begin + offset + sizeof(guint32));
 


### PR DESCRIPTION
Hello,

These are fixes we had to make to 2.6.2 to make it work on ARMv7 (Cortex A9). Please let me know what you think.

The second one is basically the same as https://github.com/libpinyin/libpinyin/pull/152, however I fixed all locations which I think could generate the same alignment trap, depending on surrounding code and compiler version. (It's possible that I didn't catch them all though.)

I included a very verbose commit message. Don't get me wrong - I know we all here understand the code. ;) The reason for the verbose explanation is that I think it's nice for the future (- who knows who's going to be working on it in the future).

What do you think?


Best regards

Matias Larsson

----

[Fix segmentation fault on ARMv7](https://github.com/libpinyin/libpinyin/commit/96e4e347103df8176118e8876c749cdd3f4f9363)

[Fix libpinyin crash on ARMv7](https://github.com/libpinyin/libpinyin/commit/85265c06730dc4cee1152803417c47044310424c)

Fix the alignment trap in get_unigram_frequency(). Fix also other
places where this same trap could happen (depending on compiler
and surrounding code).

The trap happened when the ARM GCC generated a SIMD instruction
(specifically VLDR) to load 32 bits in a single instruction, and
when the memory address was not aligned to 32 bits. VLDR traps if
the address is not aligned.

GCC generated the instruction because of the cast to uint32 from
the address. The fix is to allocate a uint32 variable in stack and
use memcpy to copy the data to that variable. This way we ensure
that appropriate instructions are generated.

**Links**

About the issue with GCC:
https://trust-in-soft.com/blog/2020/04/06/gcc-always-assumes-aligned-pointer-accesses/

How Linux does it:
https://elixir.bootlin.com/linux/v5.10.155/source/include/linux/unaligned/memmove.h#L13

ARM documentation:
https://documentation-service.arm.com/static/5f8dc043f86e16515cdbbc92?token=
    See 'A3.2.1 Unaligned data access'