### PR TITLE
1. build static library by default; 2. fix issue: make install;

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -79,6 +79,8 @@ add_custom_command(
     COMMENT
         "Building binary bigram data..."
     COMMAND
+        rm -rf bigram.db
+    COMMAND
         ${import_interpolation_BIN} --table-dir ${CMAKE_SOURCE_DIR}/data < ${CMAKE_SOURCE_DIR}/data/interpolation2.text
     COMMAND
         ${gen_unigram_BIN} --table-dir ${CMAKE_SOURCE_DIR}/data

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,6 @@ set(
 
 add_library(
     pinyin
-    SHARED
     ${LIBPINYIN_SOURCES}
 )
 


### PR DESCRIPTION
1. build static library by default, use BUILD_SHARED_LIBRARY=ON to build shared lib
2. fix ```make install``` issue #128 

Please see if it makes sense and merge if you like.