### PR TITLE
Free memory after use

### DIFF
--- a/utils/storage/gen_binary_files.cpp
+++ b/utils/storage/gen_binary_files.cpp
@@ -95,6 +95,7 @@ int main(int argc, char * argv[]){
         g_print("option parsing failed:%s\n", error->message);
         exit(EINVAL);
     }
+    g_option_context_free(context);
 
     SystemTableInfo2 system_table_info;
 


### PR DESCRIPTION
Found and verified this via a report from `valgrind --tool=memcheck --leak-check=full ../utils/storage/gen_binary_files --table-dir ../data`