### PR TITLE
Build shared library on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,16 @@ AC_ARG_ENABLE(libzhuyin,
 )
 AM_CONDITIONAL(ENABLE_LIBZHUYIN, test x"$enable_libzhuyin" = x"yes")
 
+AC_CANONICAL_HOST
+build_windows=no
+case "${host_os}" in
+    cygwin*|mingw*)
+        build_windows=yes
+        ;;
+    *)
+        ;;
+esac
+AM_CONDITIONAL([WINDOWS], [test x"$build_windows" = x"yes"])
 
 AC_CONFIG_FILES([libpinyin.pc
                  libzhuyin.pc

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,6 +91,10 @@ libpinyin_la_LDFLAGS = -Wl,--version-script=$(srcdir)/libpinyin.ver \
 			  -version-info @LT_VERSION_INFO@
 endif
 
+if WINDOWS
+libpinyin_la_LDFLAGS += -no-undefined
+endif
+
 if ENABLE_LIBZHUYIN
 lib_LTLIBRARIES     += libzhuyin.la
 
@@ -107,6 +111,11 @@ else
 libzhuyin_la_LDFLAGS = -Wl,--version-script=$(srcdir)/libzhuyin.ver \
 			  -version-info @LT_VERSION_INFO@
 endif
+
+if WINDOWS
+libzhuyin_la_LDFLAGS += -no-undefined
+endif
+
 endif
 
 libpinyin_internal_a_SOURCES = pinyin_internal.cpp


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.5.3-1.x86_64 2024-04-03 17:25 UTC x86_64 unknown unknown Cygwin
$ cd /usr/src
$ git clone https://github.com/libpinyin/libpinyin.git
$ cd libpinyin
$ ./autogen.sh --enable-shared --disable-static
$ make V=1
: 
/bin/sh ../libtool  --tag=CXX   --mode=link g++  -g -O2 -Wl,--version-script=./libpinyin.ver -version-info 15:0  -o libpinyin.la -rpath /usr/local/lib storage/phrase_index.lo storage/phrase_large_table2.lo storage/phrase_large_table3.lo storage/ngram.lo storage/tag_utility.lo storage/chewing_key.lo storage/pinyin_parser2.lo storage/zhuyin_parser2.lo storage/phonetic_key_matrix.lo storage/chewing_large_table.lo storage/chewing_large_table2.lo storage/table_info.lo lookup/pinyin_lookup2.lo lookup/phrase_lookup.lo lookup/lookup.lo lookup/phonetic_lookup.lo storage/ngram_bdb.lo storage/phrase_large_table3_bdb.lo storage/chewing_large_table2_bdb.lo  pinyin.lo -lglib-2.0 -lintl -ldb
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
```

Due to Windows platform limitations, this option is required when building shared libraries.
Without this option, only static libraries can be built.

https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
> This option should be used if the package has been ported to build clean dlls on win32 platforms. Usually this means that any library data items are exported with __declspec(dllexport) and imported with __declspec(dllimport). If this option is not used, libtool will assume that the package libraries are not dll clean and will build only static libraries on win32 hosts.
> 
> Provision must be made to pass -no-undefined to libtool in link mode from the package Makefile. Naturally, if you pass -no-undefined, you must ensure that all the library symbols really are defined at link time!
