### PR TITLE
Fix memory leak in kyotocabinet based tables

### DIFF
--- a/src/storage/chewing_large_table2_kyotodb.cpp
+++ b/src/storage/chewing_large_table2_kyotodb.cpp
@@ -568,6 +568,7 @@ int ChewingLargeTable2::search_suggestion
         result = search_suggestion_internal
             (phrase_length, chunk, prefix_len, prefix_keys, tokens) | result;
         chunk.set_size(0);
+        delete [] bkbuf;
         delete [] bvbuf;
 
         retval = cursor->step();
@@ -578,6 +579,10 @@ int ChewingLargeTable2::search_suggestion
 
         bksiz = 0;
         bkbuf = cursor->get_key(&bksiz);
+    }
+
+    if (bkbuf) {
+        delete [] bkbuf;
     }
 
     delete cursor;

--- a/src/storage/phrase_large_table3_kyotodb.cpp
+++ b/src/storage/phrase_large_table3_kyotodb.cpp
@@ -230,6 +230,7 @@ int PhraseLargeTable3::search_suggestion(int phrase_length,
         m_entry->m_chunk.set_chunk(bvbuf, bvsiz, NULL);
         result = m_entry->search(tokens) | result;
         m_entry->m_chunk.set_size(0);
+        delete [] bkbuf;
         delete [] bvbuf;
 
         retval = cursor->step();
@@ -240,6 +241,10 @@ int PhraseLargeTable3::search_suggestion(int phrase_length,
 
         bksiz = 0;
         bkbuf = cursor->get_key(&bksiz);
+    }
+
+    if (bkbuf) {
+        delete [] bkbuf;
     }
 
     delete cursor;


### PR DESCRIPTION
The heap memory consumption grows gradually in ibus-libpinyin 1.16.2. The root reason is a memory leak in `ChewingLargeTable2::search_suggestion`, where the buffer returned by `cursor->get_key(&bksiz)` is not freed. This buffer should be freed manually according to the [kyotocabinet documentation](https://dbmx.net/kyotocabinet/api/classkyotocabinet_1_1BasicDB_1_1Cursor.html#a7777ed7c57ee0a3ad26ed14a4edbade0). A similar problem is also found in `PhraseLargeTable3::search_suggestion`.
![massif-visualizer](https://github.com/user-attachments/assets/d9b8fa74-8b74-465b-b572-c6908813a34d)
