### PR TITLE
Remove libpinyin_internal_a_LIBADD

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -123,8 +123,6 @@ endif
 
 libpinyin_internal_a_SOURCES = pinyin_internal.cpp
 
-libpinyin_internal_a_LIBADD = storage/libstorage.a lookup/liblookup.a
-
 ## Note:
 ## As libpinyin internal interface will change, only provides static library
 ##   to catch errors when compiling instead of running.


### PR DESCRIPTION
Fixes #158

`LIBADD` should only have objects (`*.$(OBJEXT)`) not libraries
* https://www.gnu.org/software/automake/manual/html_node/A-Library.html
* https://www.gnu.org/software/automake/manual/html_node/Program-and-Library-Variables.html#index-maude_005fLIBADD-1

It looks like the static libraries are already specified whenever used, which I'm guessing is due to `LIBADD` not doing anything:
https://github.com/libpinyin/libpinyin/blob/803c358ddd1308d79c2396d6a44c68ff2cb7d38d/utils/segment/Makefile.am#L26-L28

With changes, build passed for me on both macOS 15 (Apple clang + ld) and Ubuntu 22.04 (GCC 11 + ld.bfd):
