### PR TITLE
Fix export of `_zhuyin_get_zhuyin_string` in libzhuyin

### DIFF
--- a/src/libzhuyin.exp
+++ b/src/libzhuyin.exp
@@ -29,7 +29,7 @@ _zhuyin_clear_constraint
 _zhuyin_lookup_tokens
 _zhuyin_train
 _zhuyin_reset
-_zhuyin_get__zhuyin_string
+_zhuyin_get_zhuyin_string
 _zhuyin_get_pinyin_string
 _zhuyin_token_get_phrase
 _zhuyin_token_get_n_pronunciation


### PR DESCRIPTION
There is an extra underscore in the symbol name `_zhuyin_get_zhuyin_string` in libzhuyin's exported symbols list, causing ld to complain:

    Undefined symbols for architecture arm64:
      "_zhuyin_get__zhuyin_string", referenced from:
          <initial-undefines>
    ld: symbol(s) not found for architecture arm64
