### PR TITLE
support cmake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 ## Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ######## Project settings
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 set (PACKAGE_NAME libpinyin)
 project (${PACKAGE_NAME} CXX C)
 enable_testing()


### PR DESCRIPTION
CMake 4 has dropped support for projects that have minimum cmake version requirement <3.5 by default, so it needs to be raised to at least 3.5.