### PR TITLE
Support building static lib with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ set (
 
 set (VERSION ${LIBPINYIN_VERSION})
 
+######## Options
+option(BUILD_SHARED_LIBS "Build libpinyin as shared library" ON)
+
 ######## Validation
 
 include(CheckIncludeFileCXX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,6 @@ set(
 
 add_library(
     pinyin
-    SHARED
     ${LIBPINYIN_SOURCES}
 )
 


### PR DESCRIPTION
Remove hard-coded SHARED and let the cmake built-in BUILD_SHARED_LIBS option decide static or shared.