### PR TITLE
Replace POSIX getline with std::getline

### DIFF
--- a/src/include/memory_chunk.h
+++ b/src/include/memory_chunk.h
@@ -36,6 +36,10 @@
 #include "stl_lite.h"
 #include "pinyin_utils.h"
 
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 namespace pinyin{
 
 /*  for unmanaged mode
@@ -413,7 +417,7 @@ public:
         /* free old data */
         reset();
 
-        int fd = open(filename, O_RDONLY);
+        int fd = open(filename, O_RDONLY|O_BINARY);
         if (-1 == fd)
             return false;
 
@@ -472,7 +476,7 @@ public:
         /* free old data */
         reset();
 
-        int fd = open(filename, O_RDONLY);
+        int fd = open(filename, O_RDONLY|O_BINARY);
         if (-1 == fd)
             return false;
 
@@ -530,7 +534,7 @@ public:
      *
      */
     bool save(const char * filename){
-        int fd = open(filename, O_CREAT|O_WRONLY|O_TRUNC, 0644);
+        int fd = open(filename, O_CREAT|O_WRONLY|O_TRUNC|O_BINARY, 0644);
         if ( -1 == fd )
             return false;
 

--- a/src/pinyin.cpp
+++ b/src/pinyin.cpp
@@ -1056,7 +1056,7 @@ static bool _rename_files(pinyin_context_t * context){
             gchar * chunkpathname = g_build_filename(context->m_user_dir,
                                                      userfilename, NULL);
 
-            int result = rename(tmppathname, chunkpathname);
+            int result = g_rename(tmppathname, chunkpathname);
             if (0 != result)
                 fprintf(stderr, "rename %s to %s failed.\n",
                         tmppathname, chunkpathname);
@@ -1075,7 +1075,7 @@ static bool _rename_files(pinyin_context_t * context){
             gchar * chunkpathname = g_build_filename(context->m_user_dir,
                                                      userfilename, NULL);
 
-            int result = rename(tmppathname, chunkpathname);
+            int result = g_rename(tmppathname, chunkpathname);
             if (0 != result)
                 fprintf(stderr, "rename %s to %s failed.\n",
                         tmppathname, chunkpathname);
@@ -1091,7 +1091,7 @@ static bool _rename_files(pinyin_context_t * context){
     gchar * filename = g_build_filename
         (context->m_user_dir, USER_PINYIN_INDEX, NULL);
 
-    int result = rename(tmpfilename, filename);
+    int result = g_rename(tmpfilename, filename);
     if (0 != result)
         fprintf(stderr, "rename %s to %s failed.\n",
                 tmpfilename, filename);
@@ -1105,7 +1105,7 @@ static bool _rename_files(pinyin_context_t * context){
     filename = g_build_filename
         (context->m_user_dir, USER_PHRASE_INDEX, NULL);
 
-    result = rename(tmpfilename, filename);
+    result = g_rename(tmpfilename, filename);
     if (0 != result)
         fprintf(stderr, "rename %s to %s failed.\n",
                 tmpfilename, filename);
@@ -1118,7 +1118,7 @@ static bool _rename_files(pinyin_context_t * context){
         (context->m_user_dir, USER_BIGRAM ".tmp", NULL);
     filename = g_build_filename(context->m_user_dir, USER_BIGRAM, NULL);
 
-    result = rename(tmpfilename, filename);
+    result = g_rename(tmpfilename, filename);
     if (0 != result)
         fprintf(stderr, "rename %s to %s failed.\n",
                 tmpfilename, filename);

--- a/src/storage/Makefile.am
+++ b/src/storage/Makefile.am
@@ -63,6 +63,7 @@ noinst_HEADERS = chewing_enum.h \
 			  facade_chewing_table2.h \
 			  facade_phrase_table2.h \
 			  facade_phrase_table3.h \
+			  table_text_parser.h \
 			  table_info.h \
 			  bdb_utils.h \
 			  kyotodb_utils.h \

--- a/src/storage/chewing_large_table.cpp
+++ b/src/storage/chewing_large_table.cpp
@@ -24,6 +24,7 @@
 #include "pinyin_phrase3.h"
 #include "pinyin_parser2.h"
 #include "zhuyin_parser2.h"
+#include "table_text_parser.h"
 
 
 /* internal class definition */
@@ -668,21 +669,8 @@ bool ChewingLargeTable::load_text(FILE * infile, TABLE_PHONETIC_TYPE type) {
     phrase_token_t token;
     size_t freq;
 
-    while (!feof(infile)) {
-#ifdef __APPLE__
-        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
-                         pinyin, phrase, &token, &freq);
-#else
-        int num = fscanf(infile, "%255s %255s %u %ld",
-                         pinyin, phrase, &token, &freq);
-#endif
-
-        if (4 != num)
-            continue;
-
-        if(feof(infile))
-            break;
-
+    while (table_text_read_pinyin_record(infile, pinyin, phrase,
+                                         &token, &freq)) {
         glong len = g_utf8_strlen(phrase, -1);
 
         ChewingKeyVector keys;
@@ -708,8 +696,9 @@ bool ChewingLargeTable::load_text(FILE * infile, TABLE_PHONETIC_TYPE type) {
         };
 
         if (len != keys->len) {
-            fprintf(stderr, "ChewingLargeTable::load_text:%s\t%s\t%u\t%ld\n",
-                    pinyin, phrase, token, freq);
+            fprintf(stderr, "ChewingLargeTable::load_text:%s\t%s\t%u\t%"
+                    G_GSIZE_FORMAT "\n", pinyin, phrase, token,
+                    (gsize) freq);
             continue;
         }
 

--- a/src/storage/chewing_large_table2.cpp
+++ b/src/storage/chewing_large_table2.cpp
@@ -21,6 +21,7 @@
 #include "chewing_large_table2.h"
 #include "pinyin_parser2.h"
 #include "zhuyin_parser2.h"
+#include "table_text_parser.h"
 
 void ChewingLargeTable2::init_entries() {
     assert(NULL == m_entries);
@@ -114,21 +115,8 @@ bool ChewingLargeTable2::load_text(FILE * infile, TABLE_PHONETIC_TYPE type) {
     phrase_token_t token;
     size_t freq;
 
-    while (!feof(infile)) {
-#ifdef __APPLE__
-        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
-                         pinyin, phrase, &token, &freq);
-#else
-        int num = fscanf(infile, "%255s %255s %u %ld",
-                         pinyin, phrase, &token, &freq);
-#endif
-
-        if (4 != num)
-            continue;
-
-        if(feof(infile))
-            break;
-
+    while (table_text_read_pinyin_record(infile, pinyin, phrase,
+                                         &token, &freq)) {
         glong len = g_utf8_strlen(phrase, -1);
 
         ChewingKeyVector keys;
@@ -154,8 +142,9 @@ bool ChewingLargeTable2::load_text(FILE * infile, TABLE_PHONETIC_TYPE type) {
         };
 
         if (len != keys->len) {
-            fprintf(stderr, "ChewingLargeTable2::load_text:%s\t%s\t%u\t%ld\n",
-                    pinyin, phrase, token, freq);
+            fprintf(stderr, "ChewingLargeTable2::load_text:%s\t%s\t%u\t%"
+                    G_GSIZE_FORMAT "\n", pinyin, phrase, token,
+                    (gsize) freq);
             continue;
         }
 

--- a/src/storage/phrase_index.cpp
+++ b/src/storage/phrase_index.cpp
@@ -20,6 +20,7 @@
 
 #include "phrase_index.h"
 #include "pinyin_custom2.h"
+#include "table_text_parser.h"
 #include "unaligned_memory.h"
 
 namespace pinyin{
@@ -533,21 +534,8 @@ bool FacadePhraseIndex::load_text(guint8 phrase_index, FILE * infile,
     PhraseItem * item_ptr = new PhraseItem;
     phrase_token_t cur_token = 0;
 
-    while (!feof(infile)){
-#ifdef __APPLE__
-        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
-                         pinyin, phrase, &token, &freq);
-#else
-        int num = fscanf(infile, "%255s %255s %u %ld",
-                         pinyin, phrase, &token, &freq);
-#endif
-
-        if (4 != num)
-            continue;
-
-        if (feof(infile))
-            break;
-
+    while (table_text_read_pinyin_record(infile, pinyin, phrase,
+                                         &token, &freq)){
         assert(PHRASE_INDEX_LIBRARY_INDEX(token) == phrase_index );
 
         glong written;

--- a/src/storage/phrase_large_table2.cpp
+++ b/src/storage/phrase_large_table2.cpp
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <string.h>
 #include "phrase_large_table2.h"
+#include "table_text_parser.h"
 
 
 /* class definition */
@@ -471,21 +472,8 @@ bool PhraseLargeTable2::load_text(FILE * infile){
     phrase_token_t token;
     size_t freq;
 
-    while (!feof(infile)) {
-#ifdef __APPLE__
-        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
-                         pinyin, phrase, &token, &freq);
-#else
-        int num = fscanf(infile, "%255s %255s %u %ld",
-                         pinyin, phrase, &token, &freq);
-#endif
-
-        if (4 != num)
-            continue;
-
-        if (feof(infile))
-            break;
-
+    while (table_text_read_pinyin_record(infile, pinyin, phrase,
+                                         &token, &freq)) {
         glong phrase_len = g_utf8_strlen(phrase, -1);
         ucs4_t * new_phrase = g_utf8_to_ucs4(phrase, -1, NULL, NULL, NULL);
         add_index(phrase_len, new_phrase, token);

--- a/src/storage/phrase_large_table3.cpp
+++ b/src/storage/phrase_large_table3.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "phrase_large_table3.h"
+#include "table_text_parser.h"
 
 namespace pinyin{
 
@@ -127,21 +128,8 @@ bool PhraseLargeTable3::load_text(FILE * infile){
     phrase_token_t token;
     size_t freq;
 
-    while (!feof(infile)) {
-#ifdef __APPLE__
-        int num = fscanf(infile, "%255s %255[^ \t] %u %ld",
-                         pinyin, phrase, &token, &freq);
-#else
-        int num = fscanf(infile, "%255s %255s %u %ld",
-                         pinyin, phrase, &token, &freq);
-#endif
-
-        if (4 != num)
-            continue;
-
-        if (feof(infile))
-            break;
-
+    while (table_text_read_pinyin_record(infile, pinyin, phrase,
+                                         &token, &freq)) {
         glong phrase_len = g_utf8_strlen(phrase, -1);
         ucs4_t * new_phrase = g_utf8_to_ucs4(phrase, -1, NULL, NULL, NULL);
         add_index(phrase_len, new_phrase, token);

--- a/src/storage/punct_table.cpp
+++ b/src/storage/punct_table.cpp
@@ -20,6 +20,7 @@
 
 
 #include "punct_table.h"
+#include "table_text_parser.h"
 
 using namespace pinyin;
 
@@ -182,21 +183,8 @@ bool PunctTable::load_text(FILE * infile) {
     char punct[256];
     size_t freq;
 
-    while (!feof(infile)) {
-#ifdef __APPLE__
-        int num = fscanf(infile, "%u %255[^ \t] %255[^ \t] %ld",
-                         &token, phrase, punct, &freq);
-#else
-        int num = fscanf(infile, "%u %255s %255s  %ld",
-                         &token, phrase, punct, &freq);
-#endif
-
-        if (4 != num)
-            continue;
-
-        if (feof(infile))
-            break;
-
+    while (table_text_read_punct_record(infile, &token, phrase, punct,
+                                        &freq)) {
         append_punctuation(token, punct);
     }
     return true;

--- a/src/storage/table_text_parser.h
+++ b/src/storage/table_text_parser.h
@@ -1,0 +1,125 @@
+/*
+ * libpinyin
+ * Library to deal with pinyin.
+ *
+ * Copyright (C) 2026 Hong An
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TABLE_TEXT_PARSER_H
+#define TABLE_TEXT_PARSER_H
+
+#include <array>
+#include <errno.h>
+#include <limits>
+#include <stdio.h>
+#include <string.h>
+#include <glib.h>
+#include "novel_types.h"
+
+namespace pinyin{
+
+static inline bool table_text_split_line(char * line,
+                                         std::array<char *, 4> & fields) {
+    char * cur = line;
+
+    for (size_t i = 0; i < fields.size(); ++i) {
+        cur += strspn(cur, " \t");
+        if (*cur == '\0' || *cur == '\r' || *cur == '\n')
+            return false;
+
+        fields[i] = cur;
+        cur += strcspn(cur, " \t\r\n");
+        if (*cur != '\0') {
+            *cur = '\0';
+            ++cur;
+        }
+    }
+
+    return true;
+}
+
+template<typename Integer>
+static inline bool table_text_parse_integer(const char * field,
+                                            Integer & value) {
+    if (field == NULL || *field == '\0' || *field == '-')
+        return false;
+
+    errno = 0;
+    char * end = NULL;
+    guint64 parsed = g_ascii_strtoull(field, &end, 10);
+    if (errno != 0 || end == field || *end != '\0' ||
+        parsed > (guint64) std::numeric_limits<Integer>::max())
+        return false;
+
+    value = (Integer) parsed;
+    return true;
+}
+
+static inline bool table_text_copy_field(char dest[256], const char * field) {
+    return field != NULL && g_strlcpy(dest, field, 256) < 256;
+}
+
+static inline bool table_text_read_pinyin_record(FILE * infile,
+                                                 char pinyin[256],
+                                                 char phrase[256],
+                                                 phrase_token_t * token,
+                                                 size_t * freq) {
+    char line[4096];
+
+    while (fgets(line, sizeof(line), infile)) {
+        std::array<char *, 4> fields;
+        if (!table_text_split_line(line, fields))
+            continue;
+
+        if (!table_text_copy_field(pinyin, fields[0]) ||
+            !table_text_copy_field(phrase, fields[1]) ||
+            !table_text_parse_integer<phrase_token_t>(fields[2], *token) ||
+            !table_text_parse_integer<size_t>(fields[3], *freq))
+            continue;
+
+        return true;
+    }
+
+    return false;
+}
+
+static inline bool table_text_read_punct_record(FILE * infile,
+                                                phrase_token_t * token,
+                                                char phrase[256],
+                                                char punct[256],
+                                                size_t * freq) {
+    char line[4096];
+
+    while (fgets(line, sizeof(line), infile)) {
+        std::array<char *, 4> fields;
+        if (!table_text_split_line(line, fields))
+            continue;
+
+        if (!table_text_parse_integer<phrase_token_t>(fields[0], *token) ||
+            !table_text_copy_field(phrase, fields[1]) ||
+            !table_text_copy_field(punct, fields[2]) ||
+            !table_text_parse_integer<size_t>(fields[3], *freq))
+            continue;
+
+        return true;
+    }
+
+    return false;
+}
+
+};
+
+#endif

--- a/src/zhuyin.cpp
+++ b/src/zhuyin.cpp
@@ -606,7 +606,7 @@ bool zhuyin_save(zhuyin_context_t * context){
                                                      userfilename, NULL);
             log->save(tmppathname);
 
-            int result = rename(tmppathname, chunkpathname);
+            int result = g_rename(tmppathname, chunkpathname);
             if (0 != result)
                 fprintf(stderr, "rename %s to %s failed.\n",
                         tmppathname, chunkpathname);
@@ -632,7 +632,7 @@ bool zhuyin_save(zhuyin_context_t * context){
 
             chunk->save(tmppathname);
 
-            int result = rename(tmppathname, chunkpathname);
+            int result = g_rename(tmppathname, chunkpathname);
             if (0 != result)
                 fprintf(stderr, "rename %s to %s failed.\n",
                         tmppathname, chunkpathname);
@@ -652,7 +652,7 @@ bool zhuyin_save(zhuyin_context_t * context){
 
     context->m_pinyin_table->store(tmpfilename);
 
-    int result = rename(tmpfilename, filename);
+    int result = g_rename(tmpfilename, filename);
     if (0 != result)
         fprintf(stderr, "rename %s to %s failed.\n",
                 tmpfilename, filename);
@@ -669,7 +669,7 @@ bool zhuyin_save(zhuyin_context_t * context){
 
     context->m_phrase_table->store(tmpfilename);
 
-    result = rename(tmpfilename, filename);
+    result = g_rename(tmpfilename, filename);
     if (0 != result)
         fprintf(stderr, "rename %s to %s failed.\n",
                 tmpfilename, filename);
@@ -684,7 +684,7 @@ bool zhuyin_save(zhuyin_context_t * context){
     filename = g_build_filename(context->m_user_dir, USER_BIGRAM, NULL);
     context->m_user_bigram->save_db(tmpfilename);
 
-    result = rename(tmpfilename, filename);
+    result = g_rename(tmpfilename, filename);
     if (0 != result)
         fprintf(stderr, "rename %s to %s failed.\n",
                 tmpfilename, filename);

--- a/tests/lookup/test_phrase_lookup.cpp
+++ b/tests/lookup/test_phrase_lookup.cpp
@@ -25,6 +25,8 @@
 
 #include <stdio.h>
 #include <locale.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "tests_helper.h"
 
@@ -89,21 +91,15 @@ int main(int argc, char * argv[]){
                                &system_bigram, &user_bigram);
 
     /* try one sentence */
-    char * linebuf = NULL;
-    size_t size = 0;
-    ssize_t read;
-    while( (read = getline(&linebuf, &size, stdin)) != -1 ){
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+        if ( linebuf == "quit" )
             break;
 
         /* check non-ucs4 characters */
-        const glong num_of_chars = g_utf8_strlen(linebuf, -1);
+        const glong num_of_chars = g_utf8_strlen(linebuf.c_str(), -1);
         glong len = 0;
-        ucs4_t * sentence = g_utf8_to_ucs4(linebuf, -1, NULL, &len, NULL);
+        ucs4_t * sentence = g_utf8_to_ucs4(linebuf.c_str(), -1, NULL, &len, NULL);
         if ( len != num_of_chars ) {
             fprintf(stderr, "non-ucs4 characters are not accepted.\n");
             g_free(sentence);
@@ -114,6 +110,5 @@ int main(int argc, char * argv[]){
         g_free(sentence);
     }
 
-    free(linebuf);
     return 0;
 }

--- a/tests/lookup/test_pinyin_lookup.cpp
+++ b/tests/lookup/test_pinyin_lookup.cpp
@@ -25,6 +25,8 @@
 
 #include "timer.h"
 #include <string.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "tests_helper.h"
 
@@ -70,13 +72,9 @@ int main( int argc, char * argv[]){
     ForwardPhoneticConstraints constraints(&phrase_index);
     NBestMatchResults results;
 
-    char* linebuf = NULL; size_t size = 0; ssize_t read;
-    while( (read = getline(&linebuf, &size, stdin)) != -1 ){
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+        if ( linebuf == "quit" )
             break;
 	
         FullPinyinParser2 parser;
@@ -84,7 +82,7 @@ int main( int argc, char * argv[]){
         ChewingKeyRestVector key_rests =
             g_array_new(FALSE, FALSE, sizeof(ChewingKeyRest));
         int parsed_len = parser.parse(options, keys, key_rests,
-                                      linebuf, strlen(linebuf));
+                                      linebuf.c_str(), linebuf.size());
 
         PhoneticKeyMatrix matrix;
 
@@ -134,6 +132,5 @@ int main( int argc, char * argv[]){
 
     g_array_free(prefixes, TRUE);
 
-    free(linebuf);
     return 0;
 }

--- a/tests/storage/test_chewing_table.cpp
+++ b/tests/storage/test_chewing_table.cpp
@@ -24,6 +24,8 @@
 
 #include "timer.h"
 #include <string.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "tests_helper.h"
 
@@ -56,13 +58,9 @@ int main(int argc, char * argv[]) {
     largetable.load(new_chunk);
 #endif
 
-    char* linebuf = NULL; size_t size = 0; ssize_t read;
-    while ((read = getline(&linebuf, &size, stdin)) != -1) {
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-	if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+	if ( linebuf == "quit" )
 	    break;
 
         FullPinyinParser2 parser;
@@ -70,7 +68,7 @@ int main(int argc, char * argv[]) {
         ChewingKeyRestVector key_rests =
             g_array_new(FALSE, FALSE, sizeof(ChewingKeyRest));
 
-        parser.parse(options, keys, key_rests, linebuf, strlen(linebuf));
+        parser.parse(options, keys, key_rests, linebuf.c_str(), linebuf.size());
         if (0 == keys->len) {
             fprintf(stderr, "Invalid input.\n");
             continue;
@@ -107,9 +105,6 @@ int main(int argc, char * argv[]) {
         g_array_free(keys, TRUE);
         g_array_free(key_rests, TRUE);
     }
-
-    if (linebuf)
-        free(linebuf);
 
     /* mask out all index items. */
     largetable.mask_out(0x0, 0x0);

--- a/tests/storage/test_matrix.cpp
+++ b/tests/storage/test_matrix.cpp
@@ -24,6 +24,8 @@
 
 #include "timer.h"
 #include <stdlib.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "tests_helper.h"
 
@@ -110,13 +112,9 @@ int main(int argc, char * argv[]) {
 
     PhoneticKeyMatrix matrix;
 
-    char* linebuf = NULL; size_t size = 0; ssize_t read;
-    while( (read = getline(&linebuf, &size, stdin)) != -1 ){
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+        if ( linebuf == "quit" )
             break;
 
         int len = 0;
@@ -125,7 +123,7 @@ int main(int argc, char * argv[]) {
             matrix.clear_all();
 
             len = parser->parse(options, keys, key_rests,
-                                linebuf, strlen(linebuf));
+                                linebuf.c_str(), linebuf.size());
 
             fill_matrix(&matrix, keys, key_rests, len);
 
@@ -168,9 +166,6 @@ int main(int argc, char * argv[]) {
 
         phrase_index.destroy_ranges(ranges);
     }
-
-    if (linebuf)
-        free(linebuf);
 
     delete parser;
 

--- a/tests/storage/test_parser2.cpp
+++ b/tests/storage/test_parser2.cpp
@@ -29,6 +29,8 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 
 
@@ -93,13 +95,9 @@ int main(int argc, char * argv[]) {
     if (!parser)
         parser = new FullPinyinParser2();
 
-    char* linebuf = NULL; size_t size = 0; ssize_t read;
-    while( (read = getline(&linebuf, &size, stdin)) != -1 ){
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+        if ( linebuf == "quit" )
             break;
 
 #if 0
@@ -118,7 +116,7 @@ int main(int argc, char * argv[]) {
         guint32 start_time = record_time();
         for ( size_t i = 0; i < bench_times; ++i)
             len = parser->parse(options, keys, key_rests,
-                                linebuf, strlen(linebuf));
+                                linebuf.c_str(), linebuf.size());
 
         print_time(start_time, bench_times);
 
@@ -141,9 +139,6 @@ int main(int argc, char * argv[]) {
 #endif
 
     }
-
-    if (linebuf)
-        free(linebuf);
 
     delete parser;
 

--- a/tests/storage/test_phrase_table.cpp
+++ b/tests/storage/test_phrase_table.cpp
@@ -4,6 +4,8 @@
 
 #include "timer.h"
 #include <string.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "tests_helper.h"
 
@@ -35,17 +37,13 @@ int main(int argc, char * argv[]){
     largetable.load(chunk);
 #endif
 
-    char* linebuf = NULL; size_t size = 0; ssize_t read;
-    while ((read = getline(&linebuf, &size, stdin)) != -1) {
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+        if ( linebuf == "quit" )
             break;
 
-        glong phrase_len = g_utf8_strlen(linebuf, -1);
-        ucs4_t * new_phrase = g_utf8_to_ucs4(linebuf, -1, NULL, NULL, NULL);
+        glong phrase_len = g_utf8_strlen(linebuf.c_str(), -1);
+        ucs4_t * new_phrase = g_utf8_to_ucs4(linebuf.c_str(), -1, NULL, NULL, NULL);
 
         if (0 == phrase_len)
             continue;
@@ -93,9 +91,6 @@ int main(int argc, char * argv[]){
         phrase_index.destroy_tokens(tokens);
         g_free(new_phrase);
     }
-
-    if ( linebuf )
-        free(linebuf);
 
     /* mask out all index items. */
     largetable.mask_out(0x0, 0x0);

--- a/tests/test_chewing.cpp
+++ b/tests/test_chewing.cpp
@@ -27,6 +27,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <iostream>
+#include <string>
 
 int main(int argc, char * argv[]){
     pinyin_context_t * context =
@@ -34,18 +36,12 @@ int main(int argc, char * argv[]){
 
     pinyin_instance_t * instance = pinyin_alloc_instance(context);
 
-    char* linebuf = NULL;
-    size_t size = 0;
-    ssize_t read;
-    while( (read = getline(&linebuf, &size, stdin)) != -1 ){
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+        if ( linebuf == "quit" )
             break;
 
-        size_t len = pinyin_parse_more_chewings(instance, linebuf);
+        size_t len = pinyin_parse_more_chewings(instance, linebuf.c_str());
         pinyin_guess_sentence(instance);
 
         char * sentence = NULL;
@@ -72,6 +68,5 @@ int main(int argc, char * argv[]){
     pinyin_save(context);
     pinyin_fini(context);
 
-    free(linebuf);
     return 0;
 }

--- a/tests/test_phrase.cpp
+++ b/tests/test_phrase.cpp
@@ -27,6 +27,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <iostream>
+#include <string>
 
 int main(int argc, char * argv[]){
     pinyin_context_t * context =
@@ -34,18 +36,12 @@ int main(int argc, char * argv[]){
 
     pinyin_instance_t * instance = pinyin_alloc_instance(context);
 
-    char* linebuf = NULL;
-    size_t size = 0;
-    ssize_t read;
-    while( (read = getline(&linebuf, &size, stdin)) != -1 ){
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-	if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+	if ( linebuf == "quit" )
             break;
 
-        pinyin_phrase_segment(instance, linebuf);
+        pinyin_phrase_segment(instance, linebuf.c_str());
         guint len = 0;
         pinyin_get_n_phrase(instance, &len);
 
@@ -72,6 +68,5 @@ int main(int argc, char * argv[]){
     pinyin_save(context);
     pinyin_fini(context);
 
-    free(linebuf);
     return 0;
 }

--- a/tests/test_pinyin.cpp
+++ b/tests/test_pinyin.cpp
@@ -27,6 +27,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <iostream>
+#include <string>
 
 int main(int argc, char * argv[]){
     pinyin_context_t * context =
@@ -39,36 +41,27 @@ int main(int argc, char * argv[]){
 
     pinyin_instance_t * instance = pinyin_alloc_instance(context);
 
-    char * prefixbuf = NULL; size_t prefixsize = 0;
-    char * linebuf = NULL; size_t linesize = 0;
-    ssize_t read;
+    std::string prefixbuf;
+    std::string linebuf;
 
     while( TRUE ){
         fprintf(stdout, "prefix:");
         fflush(stdout);
 
-        if ((read = getline(&prefixbuf, &prefixsize, stdin)) == -1)
+        if (!std::getline(std::cin, prefixbuf))
             break;
-
-        if ( '\n' == prefixbuf[strlen(prefixbuf) - 1] ) {
-            prefixbuf[strlen(prefixbuf) - 1] = '\0';
-        }
 
         fprintf(stdout, "pinyin:");
         fflush(stdout);
 
-        if ((read = getline(&linebuf, &linesize, stdin)) == -1)
+        if (!std::getline(std::cin, linebuf))
             break;
 
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        if ( strcmp ( linebuf, "quit" ) == 0)
+        if ( linebuf == "quit" )
             break;
 
-        size_t len = pinyin_parse_more_full_pinyins(instance, linebuf);
-        pinyin_guess_sentence_with_prefix(instance, prefixbuf);
+        size_t len = pinyin_parse_more_full_pinyins(instance, linebuf.c_str());
+        pinyin_guess_sentence_with_prefix(instance, prefixbuf.c_str());
         guint sort_option = SORT_BY_PHRASE_LENGTH | SORT_BY_FREQUENCY;
         pinyin_guess_candidates(instance, 0, sort_option);
 
@@ -104,6 +97,5 @@ int main(int argc, char * argv[]){
     pinyin_save(context);
     pinyin_fini(context);
 
-    free(prefixbuf); free(linebuf);
     return 0;
 }

--- a/tests/test_zhuyin.cpp
+++ b/tests/test_zhuyin.cpp
@@ -27,6 +27,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <iostream>
+#include <string>
 
 int main(int argc, char * argv[]){
     zhuyin_context_t * context =
@@ -34,19 +36,13 @@ int main(int argc, char * argv[]){
 
     zhuyin_instance_t * instance = zhuyin_alloc_instance(context);
 
-    char* linebuf = NULL;
-    size_t size = 0;
-    ssize_t read;
-    while( (read = getline(&linebuf, &size, stdin)) != -1 ){
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-	if ( strcmp ( linebuf, "quit" ) == 0)
+    std::string linebuf;
+    while (std::getline(std::cin, linebuf)) {
+	if ( linebuf == "quit" )
             break;
 
         zhuyin_parse_more_chewings
-            (instance, linebuf);
+            (instance, linebuf.c_str());
         zhuyin_guess_sentence(instance);
 
         char * sentence = NULL;
@@ -66,6 +62,5 @@ int main(int argc, char * argv[]){
     zhuyin_save(context);
     zhuyin_fini(context);
 
-    free(linebuf);
     return 0;
 }

--- a/utils/segment/mergeseq.cpp
+++ b/utils/segment/mergeseq.cpp
@@ -25,7 +25,10 @@
 #include <stdio.h>
 #include <locale.h>
 #include <string.h>
+#include <fstream>
 #include <glib.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "utils_helper.h"
 
@@ -195,7 +198,8 @@ bool feed_line(FacadePhraseTable3 * phrase_table,
 
 
 int main(int argc, char * argv[]){
-    FILE * input = stdin;
+    std::istream * input = &std::cin;
+    std::ifstream input_file;
     FILE * output = stdout;
 
     setlocale(LC_ALL, "");
@@ -224,11 +228,12 @@ int main(int argc, char * argv[]){
     }
 
     if (2 == argc) {
-        input = fopen(argv[1], "r");
-        if (NULL == input) {
+        input_file.open(argv[1]);
+        if (!input_file) {
             perror("open file failed");
             exit(EINVAL);
         }
+        input = &input_file;
     }
 
     SystemTableInfo2 system_table_info;
@@ -255,18 +260,14 @@ int main(int argc, char * argv[]){
     GArray * unichars = g_array_new(TRUE, TRUE, sizeof(ucs4_t));
     GArray * tokeninfos = g_array_new(TRUE, TRUE, sizeof(TokenInfo));
 
-    char * linebuf = NULL; size_t size = 0; ssize_t read;
-    while( (read = getline(&linebuf, &size, input)) != -1 ){
-        if ( '\n' ==  linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        if (0 == strlen(linebuf))
+    std::string linebuf;
+    while (std::getline(*input, linebuf)) {
+        if (linebuf.empty())
             continue;
 
         feed_line(&phrase_table, &phrase_index,
                   unichars, tokeninfos,
-                  linebuf, output);
+                  linebuf.c_str(), output);
     }
 
     /* append one null token for EOF. */
@@ -276,8 +277,6 @@ int main(int argc, char * argv[]){
 
     g_array_free(unichars, TRUE);
     g_array_free(tokeninfos, TRUE);
-    free(linebuf);
-    fclose(input);
     fclose(output);
     return 0;
 }

--- a/utils/segment/ngseg.cpp
+++ b/utils/segment/ngseg.cpp
@@ -25,6 +25,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <locale.h>
+#include <fstream>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "utils_helper.h"
 
@@ -101,7 +104,8 @@ bool deal_with_unknown(GArray * current_ucs4, FILE * output){
 
 
 int main(int argc, char * argv[]){
-    FILE * input = stdin;
+    std::istream * input = &std::cin;
+    std::ifstream input_file;
     FILE * output = stdout;
 
     setlocale(LC_ALL, "");
@@ -130,11 +134,12 @@ int main(int argc, char * argv[]){
     }
 
     if (2 == argc) {
-        input = fopen(argv[1], "r");
-        if (NULL == input) {
+        input_file.open(argv[1]);
+        if (!input_file) {
             perror("open file failed");
             exit(EINVAL);
         }
+        input = &input_file;
     }
 
     SystemTableInfo2 system_table_info;
@@ -179,18 +184,14 @@ int main(int argc, char * argv[]){
     phrase_index.prepare_tokens(tokens);
 
     /* split the sentence */
-    char * linebuf = NULL; size_t size = 0; ssize_t read;
-    while( (read = getline(&linebuf, &size, input)) != -1 ){
-        if ( '\n' ==  linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
+    std::string linebuf;
+    while (std::getline(*input, linebuf)) {
         /* check non-ucs4 characters */
-        const glong num_of_chars = g_utf8_strlen(linebuf, -1);
+        const glong num_of_chars = g_utf8_strlen(linebuf.c_str(), -1);
         glong len = 0;
-        ucs4_t * sentence = g_utf8_to_ucs4(linebuf, -1, NULL, &len, NULL);
+        ucs4_t * sentence = g_utf8_to_ucs4(linebuf.c_str(), -1, NULL, &len, NULL);
         if ( len != num_of_chars ) {
-            fprintf(stderr, "non-ucs4 characters encountered:%s.\n", linebuf);
+            fprintf(stderr, "non-ucs4 characters encountered:%s.\n", linebuf.c_str());
             fprintf(output, "%d \n", null_token);
             continue;
         }
@@ -255,8 +256,6 @@ int main(int argc, char * argv[]){
     /* print enter at file tail */
     fprintf(output, "%d \n", null_token);
     g_array_free(current_ucs4, TRUE);
-    free(linebuf);
-    fclose(input);
     fclose(output);
     return 0;
 }

--- a/utils/segment/spseg.cpp
+++ b/utils/segment/spseg.cpp
@@ -25,7 +25,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <locale.h>
+#include <fstream>
 #include <glib.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "utils_helper.h"
 
@@ -196,7 +199,8 @@ bool deal_with_unknown(GArray * current_ucs4, FILE * output){
 
 
 int main(int argc, char * argv[]){
-    FILE * input = stdin;
+    std::istream * input = &std::cin;
+    std::ifstream input_file;
     FILE * output = stdout;
 
     setlocale(LC_ALL, "");
@@ -225,11 +229,12 @@ int main(int argc, char * argv[]){
     }
 
     if (2 == argc) {
-        input = fopen(argv[1], "r");
-        if (NULL == input) {
+        input_file.open(argv[1]);
+        if (!input_file) {
             perror("open file failed");
             exit(EINVAL);
         }
+        input = &input_file;
     }
 
     SystemTableInfo2 system_table_info;
@@ -260,18 +265,14 @@ int main(int argc, char * argv[]){
     memset(tokens, 0, sizeof(PhraseTokens));
     phrase_index.prepare_tokens(tokens);
 
-    char * linebuf = NULL; size_t size = 0; ssize_t read;
-    while( (read = getline(&linebuf, &size, input)) != -1 ){
-        if ( '\n' ==  linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
+    std::string linebuf;
+    while (std::getline(*input, linebuf)) {
         /* check non-ucs4 characters. */
-        const glong num_of_chars = g_utf8_strlen(linebuf, -1);
+        const glong num_of_chars = g_utf8_strlen(linebuf.c_str(), -1);
         glong len = 0;
-        ucs4_t * sentence = g_utf8_to_ucs4(linebuf, -1, NULL, &len, NULL);
+        ucs4_t * sentence = g_utf8_to_ucs4(linebuf.c_str(), -1, NULL, &len, NULL);
         if ( len != num_of_chars ) {
-            fprintf(stderr, "non-ucs4 characters encountered:%s.\n", linebuf);
+            fprintf(stderr, "non-ucs4 characters encountered:%s.\n", linebuf.c_str());
             fprintf(output, "%d \n", null_token);
             continue;
         }
@@ -338,8 +339,6 @@ int main(int argc, char * argv[]){
     /* print enter at file tail */
     fprintf(output, "%d \n", null_token);
     g_array_free(current_ucs4, TRUE);
-    free(linebuf);
-    fclose(input);
     fclose(output);
     return 0;
 }

--- a/utils/storage/gen_zhuyin_table.cpp
+++ b/utils/storage/gen_zhuyin_table.cpp
@@ -24,7 +24,9 @@
 #endif
 
 #include <stdio.h>
+#include <fstream>
 #include <glib.h>
+#include <string>
 #include "pinyin_internal.h"
 
 
@@ -136,38 +138,28 @@ int main(int argc, char * argv[]){
 }
 
 void feed_file ( const char * filename){
-    FILE * infile = fopen(filename, "r");
-    if ( NULL == infile ){
+    std::ifstream infile(filename);
+    if (!infile) {
         fprintf(stderr, "Can't open file %s.\n", filename);
         exit(ENOENT);
     }
 
-    char * linebuf = NULL; size_t size = 0; ssize_t read;
-    while( (read = getline(&linebuf, &size, infile)) != -1 ){
-        if ( '\n' ==  linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
+    std::string linebuf;
+    while (std::getline(infile, linebuf)) {
         /* assume tsi.src only use the single space to separate tokens. */
-        gchar ** strs = g_strsplit_set(linebuf, " ", 3);
+        gchar ** strs = g_strsplit_set(linebuf.c_str(), " ", 3);
 
         const char * phrase = strs[0];
         guint32 freq = atoi(strs[1]);
         const char * pinyin = strs[2];
 
         if (3 != g_strv_length(strs)) {
-            fprintf(stderr, "wrong line format:%s\n", linebuf);
+            fprintf(stderr, "wrong line format:%s\n", linebuf.c_str());
             continue;
         }
 
-	if (feof(infile))
-            break;
-
 	feed_line(phrase, pinyin, freq);
     }
-
-    free(linebuf);
-    fclose(infile);
 }
 
 void feed_line(const char * phrase, const char * pinyin, const guint32 freq) {

--- a/utils/storage/import_interpolation.cpp
+++ b/utils/storage/import_interpolation.cpp
@@ -25,6 +25,8 @@
 #include <stdio.h>
 #include <locale.h>
 #include <glib.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "utils_helper.h"
 
@@ -51,27 +53,19 @@ static int line_type = 0;
 static GPtrArray * values = NULL;
 static GHashTable * required = NULL;
 /* variables for line buffer. */
-static char * linebuf = NULL;
-static size_t len = 0;
+static std::string linebuf;
 
 bool parse_headline();
 
-bool parse_unigram(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_unigram(std::istream & input, PhraseLargeTable3 * phrase_table,
                    FacadePhraseIndex * phrase_index);
 
-bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_bigram(std::istream & input, PhraseLargeTable3 * phrase_table,
                   FacadePhraseIndex * phrase_index,
                   Bigram * bigram);
 
-static ssize_t my_getline(FILE * input){
-    ssize_t result = getline(&linebuf, &len, input);
-    if ( result == -1 )
-        return result;
-
-    if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-        linebuf[strlen(linebuf) - 1] = '\0';
-    }
-    return result;
+static bool my_getline(std::istream & input){
+    return static_cast<bool>(std::getline(input, linebuf));
 }
 
 bool parse_headline(){
@@ -79,7 +73,7 @@ bool parse_headline(){
     check_result(taglib_add_tag(BEGIN_LINE, "\\data", 0, "model", ""));
 
     /* read "\data" line */
-    if ( !taglib_read(linebuf, line_type, values, required) ) {
+    if ( !taglib_read(linebuf.c_str(), line_type, values, required) ) {
         fprintf(stderr, "error: interpolation model expected.\n");
         return false;
     }
@@ -94,7 +88,7 @@ bool parse_headline(){
     return true;
 }
 
-bool parse_body(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_body(std::istream & input, PhraseLargeTable3 * phrase_table,
                 FacadePhraseIndex * phrase_index,
                 Bigram * bigram){
     taglib_push_state();
@@ -105,7 +99,7 @@ bool parse_body(FILE * input, PhraseLargeTable3 * phrase_table,
 
     do {
     retry:
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch(line_type) {
         case END_LINE:
             goto end;
@@ -120,21 +114,21 @@ bool parse_body(FILE * input, PhraseLargeTable3 * phrase_table,
         default:
             abort();
         }
-    } while (my_getline(input) != -1) ;
+    } while (my_getline(input)) ;
 
  end:
     taglib_pop_state();
     return true;
 }
 
-bool parse_unigram(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_unigram(std::istream & input, PhraseLargeTable3 * phrase_table,
                    FacadePhraseIndex * phrase_index){
     taglib_push_state();
 
     check_result(taglib_add_tag(GRAM_1_ITEM_LINE, "\\item", 2, "count", ""));
 
     do {
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch (line_type) {
         case GRAM_1_ITEM_LINE:{
             /* handle \item in \1-gram */
@@ -154,14 +148,14 @@ bool parse_unigram(FILE * input, PhraseLargeTable3 * phrase_table,
         default:
             abort();
         }
-    } while (my_getline(input) != -1);
+    } while (my_getline(input));
 
  end:
     taglib_pop_state();
     return true;
 }
 
-bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_bigram(std::istream & input, PhraseLargeTable3 * phrase_table,
                   FacadePhraseIndex * phrase_index,
                   Bigram * bigram){
     taglib_push_state();
@@ -170,7 +164,7 @@ bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
 
     phrase_token_t last_token = 0; SingleGram * last_single_gram = NULL;
     do {
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch (line_type) {
         case GRAM_2_ITEM_LINE:{
             /* handle \item in \2-gram */
@@ -222,7 +216,7 @@ bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
         default:
             abort();
         }
-    } while (my_getline(input) != -1);
+    } while (my_getline(input));
 
  end:
     if ( last_token && last_single_gram ) {
@@ -238,7 +232,7 @@ bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
 }
 
 int main(int argc, char * argv[]){
-    FILE * input = stdin;
+    std::istream & input = std::cin;
     const char * bigram_filename = SYSTEM_BIGRAM;
 
     setlocale(LC_ALL, "");
@@ -291,8 +285,8 @@ int main(int argc, char * argv[]){
     required = g_hash_table_new(g_str_hash, g_str_equal);
 
     /* read first line */
-    ssize_t result = my_getline(input);
-    if ( result == -1 ) {
+    bool result = my_getline(input);
+    if ( !result ) {
         fprintf(stderr, "empty file input.\n");
         exit(ENODATA);
     }
@@ -301,7 +295,7 @@ int main(int argc, char * argv[]){
         exit(ENODATA);
 
     result = my_getline(input);
-    if ( result != -1 )
+    if ( result )
         parse_body(input, &phrase_table, &phrase_index, &bigram);
 
     taglib_fini();

--- a/utils/training/eval_correction_rate.cpp
+++ b/utils/training/eval_correction_rate.cpp
@@ -25,6 +25,8 @@
 
 #include "pinyin_internal.h"
 #include "utils_helper.h"
+#include <fstream>
+#include <string>
 
 
 void print_help(){
@@ -161,26 +163,19 @@ int main(int argc, char * argv[]){
                                     &system_bigram, &user_bigram);
 
     /* open evals text. */
-    FILE * evals_file = fopen(evals_text, "r");
-    if ( NULL == evals_file ) {
+    std::ifstream evals_file(evals_text);
+    if (!evals_file) {
         fprintf(stderr, "Can't open file:%s\n", evals_text);
         exit(ENOENT);
     }
 
     /* Evaluates the correction rate of test text documents. */
     size_t tested_count = 0; size_t passed_count = 0;
-    char* linebuf = NULL; size_t size = 0;
+    std::string linebuf;
     TokenVector tokens = g_array_new(FALSE, TRUE, sizeof(phrase_token_t));
 
-    while( getline(&linebuf, &size, evals_file) ) {
-        if ( feof(evals_file) )
-            break;
-
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        TAGLIB_PARSE_SEGMENTED_LINE(&phrase_index, token, linebuf);
+    while (std::getline(evals_file, linebuf)) {
+        TAGLIB_PARSE_SEGMENTED_LINE(&phrase_index, token, linebuf.c_str());
 
         if ( null_token == token ) {
             if ( tokens->len ) { /* one test. */
@@ -208,8 +203,6 @@ int main(int argc, char * argv[]){
     printf("correction rate:%f\n", rate);
 
     g_array_free(tokens, TRUE);
-    fclose(evals_file);
-    free(linebuf);
 
     return 0;
 }

--- a/utils/training/gen_deleted_ngram.cpp
+++ b/utils/training/gen_deleted_ngram.cpp
@@ -27,6 +27,8 @@
 #include <string.h>
 #include <locale.h>
 #include <glib.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "utils_helper.h"
 
@@ -73,17 +75,10 @@ int main(int argc, char * argv[]){
     Bigram bigram;
     bigram.attach(bigram_filename, ATTACH_CREATE|ATTACH_READWRITE);
 
-    char* linebuf = NULL; size_t size = 0;
+    std::string linebuf;
     phrase_token_t last_token, cur_token = last_token = 0;
-    while( getline(&linebuf, &size, stdin) ){
-	if ( feof(stdin) )
-	    break;
-
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        TAGLIB_PARSE_SEGMENTED_LINE(&phrase_index, token, linebuf);
+    while (std::getline(std::cin, linebuf)) {
+        TAGLIB_PARSE_SEGMENTED_LINE(&phrase_index, token, linebuf.c_str());
 
 	last_token = cur_token;
 	cur_token = token;
@@ -120,6 +115,5 @@ int main(int argc, char * argv[]){
         delete single_gram;
     }
 
-    free(linebuf);
     return 0;
 }

--- a/utils/training/gen_k_mixture_model.cpp
+++ b/utils/training/gen_k_mixture_model.cpp
@@ -24,7 +24,9 @@
 #endif
 
 #include <glib.h>
+#include <fstream>
 #include <locale.h>
+#include <string>
 #include "pinyin_internal.h"
 #include "utils_helper.h"
 #include "k_mixture_model.h"
@@ -62,22 +64,15 @@ static GOptionEntry entries[] =
 
 bool read_document(PhraseLargeTable3 * phrase_table,
                    FacadePhraseIndex * phrase_index,
-                   FILE * document,
+                   std::istream & document,
                    HashofDocument hash_of_document,
                    HashofUnigram hash_of_unigram){
 
-    char * linebuf = NULL;size_t size = 0;
+    std::string linebuf;
     phrase_token_t last_token, cur_token = last_token = 0;
 
-    while ( getline(&linebuf, &size, document) ){
-        if ( feof(document) )
-            break;
-
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        TAGLIB_PARSE_SEGMENTED_LINE(phrase_index, token, linebuf);
+    while (std::getline(document, linebuf)) {
+        TAGLIB_PARSE_SEGMENTED_LINE(phrase_index, token, linebuf.c_str());
 
         last_token = cur_token;
         cur_token = token;
@@ -135,8 +130,6 @@ bool read_document(PhraseLargeTable3 * phrase_table,
                             GUINT_TO_POINTER(last_token),
                             hash_of_second_word);
     }
-
-    free(linebuf);
 
     return true;
 }
@@ -356,9 +349,9 @@ int main(int argc, char * argv[]){
 
     while ( i < argc ){
         const char * filename = argv[i];
-        FILE * document = fopen(filename, "r");
-        if ( NULL == document ){
-            int err_saved = errno;
+        std::ifstream document(filename);
+        if (!document) {
+            int err_saved = errno ? errno : ENOENT;
             fprintf(stderr, "can't open file: %s.\n", filename);
             fprintf(stderr, "error:%s.\n", strerror(err_saved));
             exit(err_saved);
@@ -371,8 +364,6 @@ int main(int argc, char * argv[]){
 
         check_result(read_document(&phrase_table, &phrase_index, document,
                                    hash_of_document, hash_of_unigram));
-        fclose(document);
-        document = NULL;
 
         GHashTableIter iter;
         gpointer key, value;

--- a/utils/training/gen_ngram.cpp
+++ b/utils/training/gen_ngram.cpp
@@ -27,6 +27,8 @@
 #include <string.h>
 #include <locale.h>
 #include <glib.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "utils_helper.h"
 
@@ -41,8 +43,6 @@ static GOptionEntry entries[] =
 };
 
 int main(int argc, char * argv[]){
-    FILE * input = stdin;
-
     setlocale(LC_ALL, "");
 
     GError * error = NULL;
@@ -74,17 +74,10 @@ int main(int argc, char * argv[]){
     Bigram bigram;
     bigram.attach(bigram_filename, ATTACH_CREATE|ATTACH_READWRITE);
 
-    char* linebuf = NULL; size_t size = 0;
+    std::string linebuf;
     phrase_token_t last_token, cur_token = last_token = 0;
-    while( getline(&linebuf, &size, input) ){
-	if ( feof(input) )
-	    break;
-
-        if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-            linebuf[strlen(linebuf) - 1] = '\0';
-        }
-
-        TAGLIB_PARSE_SEGMENTED_LINE(&phrase_index, token, linebuf);
+    while (std::getline(std::cin, linebuf)) {
+        TAGLIB_PARSE_SEGMENTED_LINE(&phrase_index, token, linebuf.c_str());
 
 	last_token = cur_token;
 	cur_token = token;
@@ -124,8 +117,6 @@ int main(int argc, char * argv[]){
         delete single_gram;
     }
 
-    free(linebuf);
-    
     if (!save_phrase_index(phrase_files, &phrase_index))
         exit(ENOENT);
 

--- a/utils/training/import_k_mixture_model.cpp
+++ b/utils/training/import_k_mixture_model.cpp
@@ -24,6 +24,8 @@
 
 #include <stdio.h>
 #include <locale.h>
+#include <iostream>
+#include <string>
 #include "pinyin_internal.h"
 #include "utils_helper.h"
 #include "k_mixture_model.h"
@@ -50,29 +52,21 @@ static int line_type = 0;
 static GPtrArray * values = NULL;
 static GHashTable * required = NULL;
 /* variables for line buffer. */
-static char * linebuf = NULL;
-static size_t len = 0;
+static std::string linebuf;
 
 bool parse_headline(KMixtureModelBigram * bigram);
 
-bool parse_unigram(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_unigram(std::istream & input, PhraseLargeTable3 * phrase_table,
                    FacadePhraseIndex * phrase_index,
                    KMixtureModelBigram * bigram);
 
-bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_bigram(std::istream & input, PhraseLargeTable3 * phrase_table,
                   FacadePhraseIndex * phrase_index,
                   KMixtureModelBigram * bigram);
 
 
-static ssize_t my_getline(FILE * input){
-    ssize_t result = getline(&linebuf, &len, input);
-    if ( result == -1 )
-        return result;
-
-    if ( '\n' == linebuf[strlen(linebuf) - 1] ) {
-        linebuf[strlen(linebuf) - 1] = '\0';
-    }
-    return result;
+static bool my_getline(std::istream & input){
+    return static_cast<bool>(std::getline(input, linebuf));
 }
 
 bool parse_headline(KMixtureModelBigram * bigram){
@@ -80,7 +74,7 @@ bool parse_headline(KMixtureModelBigram * bigram){
     check_result(taglib_add_tag(BEGIN_LINE, "\\data", 0, "model:count:N:total_freq", ""));
 
     /* read "\data" line */
-    if ( !taglib_read(linebuf, line_type, values, required) ) {
+    if ( !taglib_read(linebuf.c_str(), line_type, values, required) ) {
         fprintf(stderr, "error: k mixture model expected.\n");
         return false;
     }
@@ -106,7 +100,7 @@ bool parse_headline(KMixtureModelBigram * bigram){
     return true;
 }
 
-bool parse_body(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_body(std::istream & input, PhraseLargeTable3 * phrase_table,
                 FacadePhraseIndex * phrase_index,
                 KMixtureModelBigram * bigram){
     taglib_push_state();
@@ -117,7 +111,7 @@ bool parse_body(FILE * input, PhraseLargeTable3 * phrase_table,
 
     do {
     retry:
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch(line_type) {
         case END_LINE:
             goto end;
@@ -132,14 +126,14 @@ bool parse_body(FILE * input, PhraseLargeTable3 * phrase_table,
         default:
             abort();
         }
-    } while (my_getline(input) != -1) ;
+    } while (my_getline(input)) ;
 
  end:
     taglib_pop_state();
     return true;
 }
 
-bool parse_unigram(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_unigram(std::istream & input, PhraseLargeTable3 * phrase_table,
                    FacadePhraseIndex * phrase_index,
                    KMixtureModelBigram * bigram){
     taglib_push_state();
@@ -147,7 +141,7 @@ bool parse_unigram(FILE * input, PhraseLargeTable3 * phrase_table,
     check_result(taglib_add_tag(GRAM_1_ITEM_LINE, "\\item", 2, "count:freq", ""));
 
     do {
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch (line_type) {
         case GRAM_1_ITEM_LINE:{
             /* handle \item in \1-gram */
@@ -172,14 +166,14 @@ bool parse_unigram(FILE * input, PhraseLargeTable3 * phrase_table,
         default:
             abort();
         }
-    } while (my_getline(input) != -1);
+    } while (my_getline(input));
 
  end:
     taglib_pop_state();
     return true;
 }
 
-bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
+bool parse_bigram(std::istream & input, PhraseLargeTable3 * phrase_table,
                   FacadePhraseIndex * phrase_index,
                   KMixtureModelBigram * bigram){
     taglib_push_state();
@@ -190,7 +184,7 @@ bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
     phrase_token_t last_token = null_token;
     KMixtureModelSingleGram * last_single_gram = NULL;
     do {
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch (line_type) {
         case GRAM_2_ITEM_LINE:{
             /* handle \item in \2-gram */
@@ -246,7 +240,7 @@ bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
         default:
             abort();
         }
-    } while (my_getline(input) != -1);
+    } while (my_getline(input));
 
  end:
     if ( last_token && last_single_gram ) {
@@ -262,7 +256,7 @@ bool parse_bigram(FILE * input, PhraseLargeTable3 * phrase_table,
 }
 
 int main(int argc, char * argv[]){
-    FILE * input = stdin;
+    std::istream & input = std::cin;
 
     setlocale(LC_ALL, "");
 
@@ -304,8 +298,8 @@ int main(int argc, char * argv[]){
     values = g_ptr_array_new();
     required = g_hash_table_new(g_str_hash, g_str_equal);
 
-    ssize_t result = my_getline(input);
-    if ( result == -1 ) {
+    bool result = my_getline(input);
+    if ( !result ) {
         fprintf(stderr, "empty file input.\n");
         exit(ENODATA);
     }
@@ -314,7 +308,7 @@ int main(int argc, char * argv[]){
         exit(ENODATA);
 
     result = my_getline(input);
-    if ( result != -1 )
+    if ( result )
         parse_body(input, &phrase_table, &phrase_index, &bigram);
 
     taglib_fini();

--- a/utils/training/k_mixture_model_to_interpolation.cpp
+++ b/utils/training/k_mixture_model_to_interpolation.cpp
@@ -24,6 +24,8 @@
 
 #include "pinyin_internal.h"
 #include "utils_helper.h"
+#include <iostream>
+#include <string>
 
 enum LINE_TYPE{
     BEGIN_LINE = 1,
@@ -38,31 +40,25 @@ static int line_type = 0;
 static GPtrArray * values = NULL;
 static GHashTable * required = NULL;
 /* variables for line buffer. */
-static char * linebuf = NULL;
-static size_t len = 0;
+static std::string linebuf;
 
-bool parse_headline(FILE * input, FILE * output);
+bool parse_headline(FILE * output);
 
-bool parse_unigram(FILE * input, FILE * output);
+bool parse_unigram(std::istream & input, FILE * output);
 
-bool parse_bigram(FILE * input, FILE * output);
+bool parse_bigram(std::istream & input, FILE * output);
 
-static ssize_t my_getline(FILE * input){
-    ssize_t result = getline(&linebuf, &len, input);
-    if ( result == -1 )
-        return result;
-
-    linebuf[strlen(linebuf) - 1] = '\0';
-    return result;
+static bool my_getline(std::istream & input){
+    return static_cast<bool>(std::getline(input, linebuf));
 }
 
-bool parse_headline(FILE * input, FILE * output) {
+bool parse_headline(FILE * output) {
     /* enter "\data" line */
     check_result(taglib_add_tag(BEGIN_LINE, "\\data", 0, "model",
                                 "count:N:total_freq"));
 
     /* read "\data" line */
-    if ( !taglib_read(linebuf, line_type, values, required) ) {
+    if ( !taglib_read(linebuf.c_str(), line_type, values, required) ) {
         fprintf(stderr, "error: k mixture model expected.\n");
         return false;
     }
@@ -80,7 +76,7 @@ bool parse_headline(FILE * input, FILE * output) {
     return true;
 }
 
-bool parse_body(FILE * input, FILE * output){
+bool parse_body(std::istream & input, FILE * output){
     taglib_push_state();
 
     check_result(taglib_add_tag(END_LINE, "\\end", 0, "", ""));
@@ -89,7 +85,7 @@ bool parse_body(FILE * input, FILE * output){
 
     do {
     retry:
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch(line_type) {
         case END_LINE:
             fprintf(output, "\\end\n");
@@ -107,20 +103,20 @@ bool parse_body(FILE * input, FILE * output){
         default:
             abort();
         }
-    } while (my_getline(input) != -1);
+    } while (my_getline(input));
 
  end:
     taglib_pop_state();
     return true;
 }
 
-bool parse_unigram(FILE * input, FILE * output){
+bool parse_unigram(std::istream & input, FILE * output){
     taglib_push_state();
 
     check_result(taglib_add_tag(GRAM_1_ITEM_LINE, "\\item", 2, "freq", "count"));
 
     do {
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch(line_type) {
         case GRAM_1_ITEM_LINE: {
             /* handle \item in \1-gram */
@@ -145,21 +141,21 @@ bool parse_unigram(FILE * input, FILE * output){
         default:
             abort();
         }
-    } while (my_getline(input) != -1);
+    } while (my_getline(input));
 
  end:
     taglib_pop_state();
     return true;
 }
 
-bool parse_bigram(FILE * input, FILE * output){
+bool parse_bigram(std::istream & input, FILE * output){
     taglib_push_state();
 
     check_result(taglib_add_tag(GRAM_2_ITEM_LINE, "\\item", 4,
                                 "count", "T:N_n_0:n_1:Mr"));
 
     do {
-        check_result(taglib_read(linebuf, line_type, values, required));
+        check_result(taglib_read(linebuf.c_str(), line_type, values, required));
         switch (line_type) {
         case GRAM_2_ITEM_LINE:{
             /* handle \item in \2-gram */
@@ -182,7 +178,7 @@ bool parse_bigram(FILE * input, FILE * output){
         default:
             abort();
         }
-    } while (my_getline(input) != -1);
+    } while (my_getline(input));
 
  end:
     taglib_pop_state();
@@ -190,7 +186,7 @@ bool parse_bigram(FILE * input, FILE * output){
 }
 
 int main(int argc, char * argv[]){
-    FILE * input = stdin;
+    std::istream & input = std::cin;
     FILE * output = stdout;
 
     taglib_init();
@@ -198,17 +194,17 @@ int main(int argc, char * argv[]){
     values = g_ptr_array_new();
     required = g_hash_table_new(g_str_hash, g_str_equal);
 
-    ssize_t result = my_getline(input);
-    if ( result == -1 ) {
+    bool result = my_getline(input);
+    if ( !result ) {
         fprintf(stderr, "empty file input.\n");
         exit(ENODATA);
     }
 
-    if (!parse_headline(input, output))
+    if (!parse_headline(output))
         exit(ENODATA);
 
     result = my_getline(input);
-    if ( result != -1 )
+    if ( result )
         parse_body(input, output);
 
     taglib_fini();


### PR DESCRIPTION
Use C++ standard stream-based line reading in tests and utilities so the code does not depend on POSIX getline availability on MinGW UCRT64.

Refs libpinyin/libpinyin#183.